### PR TITLE
fix: Add importmap for nbtify to resolve GitHub Pages deployment

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>img2mcstructure - Image to Minecraft Structure Converter</title>
+  <script type="importmap">
+    {
+      "imports": {
+        "nbtify": "https://esm.sh/nbtify@1.90.1"
+      }
+    }
+  </script>
   <style>
     :root {
       --bg-color: #1a1a2e;


### PR DESCRIPTION
Add browser-native import map to resolve the bare specifier "nbtify" used in dynamic imports within the client library. This ensures the module can be resolved when loaded in browsers via GitHub Pages.