### PR TITLE
feat: Add block palette customization feature to demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -280,6 +280,314 @@
         width: 100%;
       }
     }
+
+    /* Palette Editor Modal Styles */
+    .modal-overlay {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: rgba(0, 0, 0, 0.8);
+      z-index: 1000;
+      overflow-y: auto;
+      padding: 20px;
+    }
+
+    .modal-overlay.active {
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+    }
+
+    .modal {
+      background: var(--card-bg);
+      border-radius: var(--border-radius);
+      width: 100%;
+      max-width: 800px;
+      margin: 20px auto;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    }
+
+    .modal-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 24px;
+      border-bottom: 1px solid var(--accent);
+    }
+
+    .modal-header h3 {
+      font-size: 1.25rem;
+      margin: 0;
+    }
+
+    .modal-close {
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      font-size: 1.5rem;
+      cursor: pointer;
+      padding: 0;
+      line-height: 1;
+    }
+
+    .modal-close:hover {
+      color: var(--text);
+    }
+
+    .modal-body {
+      padding: 24px;
+      max-height: 60vh;
+      overflow-y: auto;
+    }
+
+    .modal-footer {
+      padding: 16px 24px;
+      border-top: 1px solid var(--accent);
+      display: flex;
+      gap: 12px;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+    }
+
+    /* Palette Editor Toolbar */
+    .palette-toolbar {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+
+    .palette-toolbar input[type="text"] {
+      flex: 1;
+      min-width: 200px;
+    }
+
+    .palette-toolbar .btn {
+      padding: 10px 16px;
+      font-size: 0.9rem;
+    }
+
+    /* Palette Block List */
+    .palette-block-list {
+      display: grid;
+      gap: 8px;
+    }
+
+    .palette-block-item {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 12px;
+      background: var(--accent);
+      border-radius: var(--border-radius);
+      transition: opacity 0.2s;
+    }
+
+    .palette-block-item.disabled {
+      opacity: 0.4;
+    }
+
+    .palette-block-item .block-toggle {
+      width: 20px;
+      height: 20px;
+      cursor: pointer;
+      accent-color: var(--highlight);
+    }
+
+    .palette-block-item .color-swatch {
+      width: 32px;
+      height: 32px;
+      border-radius: 4px;
+      border: 2px solid rgba(255, 255, 255, 0.2);
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    .palette-block-item .color-input {
+      width: 32px;
+      height: 32px;
+      padding: 0;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    .palette-block-item .block-id {
+      flex: 1;
+      font-family: monospace;
+      font-size: 0.85rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .palette-block-item .hex-input {
+      width: 80px;
+      padding: 6px 8px;
+      font-family: monospace;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+    }
+
+    .palette-block-item .btn-remove {
+      background: none;
+      border: none;
+      color: var(--error);
+      cursor: pointer;
+      padding: 4px;
+      font-size: 1.2rem;
+      line-height: 1;
+      opacity: 0.6;
+    }
+
+    .palette-block-item .btn-remove:hover {
+      opacity: 1;
+    }
+
+    /* Add Block Form */
+    .add-block-form {
+      display: flex;
+      gap: 8px;
+      padding: 12px;
+      background: rgba(0, 0, 0, 0.2);
+      border-radius: var(--border-radius);
+      margin-top: 16px;
+      flex-wrap: wrap;
+    }
+
+    .add-block-form input[type="text"] {
+      flex: 1;
+      min-width: 150px;
+    }
+
+    .add-block-form .color-input {
+      width: 40px;
+      height: 40px;
+      padding: 0;
+      border: none;
+      border-radius: var(--border-radius);
+      cursor: pointer;
+    }
+
+    /* Custom Palettes List */
+    .custom-palettes-section {
+      margin-bottom: 20px;
+    }
+
+    .custom-palettes-section h4 {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+
+    .custom-palette-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .custom-palette-chip {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      background: var(--accent);
+      border-radius: 20px;
+      font-size: 0.85rem;
+    }
+
+    .custom-palette-chip button {
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      cursor: pointer;
+      padding: 0;
+      font-size: 1rem;
+      line-height: 1;
+    }
+
+    .custom-palette-chip button:hover {
+      color: var(--error);
+    }
+
+    /* Palette Stats */
+    .palette-stats {
+      display: flex;
+      gap: 16px;
+      padding: 12px 16px;
+      background: rgba(0, 0, 0, 0.2);
+      border-radius: var(--border-radius);
+      margin-bottom: 16px;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    .palette-stats span {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    /* Save Palette Dialog */
+    .save-palette-form {
+      display: flex;
+      gap: 8px;
+      align-items: flex-end;
+    }
+
+    .save-palette-form .form-group {
+      flex: 1;
+      margin-bottom: 0;
+    }
+
+    /* Palette Selector Enhancement */
+    .palette-selector-row {
+      display: flex;
+      gap: 8px;
+      align-items: flex-end;
+    }
+
+    .palette-selector-row .form-group {
+      flex: 1;
+      margin-bottom: 0;
+    }
+
+    .palette-selector-row .btn {
+      padding: 10px 12px;
+      flex-shrink: 0;
+    }
+
+    .btn-icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* Empty State */
+    .empty-state {
+      text-align: center;
+      padding: 40px;
+      color: var(--text-muted);
+    }
+
+    .empty-state p {
+      margin-bottom: 16px;
+    }
+
+    /* Import/Export Buttons */
+    .import-export-btns {
+      display: flex;
+      gap: 8px;
+    }
+
+    .btn-small {
+      padding: 8px 12px;
+      font-size: 0.85rem;
+    }
   </style>
 </head>
 <body>
@@ -315,19 +623,28 @@
         <div class="options-container">
           <div class="form-group">
             <label for="paletteSelect">Block Palette</label>
-            <select id="paletteSelect">
-              <option value="minecraft">Minecraft (Vanilla Blocks)</option>
-              <option value="concrete">Concrete Only</option>
-              <option value="wool">Wool Only</option>
-              <option value="glass">Stained Glass</option>
-              <optgroup label="Custom Addons">
-                <option value="rgb">RGB</option>
-                <option value="rainbow">Rainbow (Full)</option>
-                <option value="rainbowGlass">Rainbow Glass</option>
-                <option value="rainbowLit">Rainbow Lit/Lamps</option>
-                <option value="rainbowMetal">Rainbow Metal</option>
-              </optgroup>
-            </select>
+            <div class="palette-selector-row">
+              <div class="form-group">
+                <select id="paletteSelect">
+                  <option value="minecraft">Minecraft (Vanilla Blocks)</option>
+                  <option value="concrete">Concrete Only</option>
+                  <option value="wool">Wool Only</option>
+                  <option value="glass">Stained Glass</option>
+                  <optgroup label="Custom Addons">
+                    <option value="rgb">RGB</option>
+                    <option value="rainbow">Rainbow (Full)</option>
+                    <option value="rainbowGlass">Rainbow Glass</option>
+                    <option value="rainbowLit">Rainbow Lit/Lamps</option>
+                    <option value="rainbowMetal">Rainbow Metal</option>
+                  </optgroup>
+                  <optgroup id="customPalettesGroup" label="Custom Palettes">
+                  </optgroup>
+                </select>
+              </div>
+              <button id="editPaletteBtn" class="btn btn-secondary btn-icon" title="Customize Palette">
+                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+              </button>
+            </div>
           </div>
           <div class="form-group">
             <label for="formatSelect">Output Format</label>
@@ -370,6 +687,52 @@
       </p>
     </footer>
   </div>
+
+  <!-- Palette Editor Modal -->
+  <div id="paletteEditorModal" class="modal-overlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Customize Block Palette</h3>
+        <button class="modal-close" id="closeModalBtn">&times;</button>
+      </div>
+      <div class="modal-body">
+        <div class="palette-toolbar">
+          <input type="text" id="paletteSearchInput" placeholder="Search blocks...">
+          <div class="import-export-btns">
+            <button class="btn btn-secondary btn-small" id="importPaletteBtn">Import JSON</button>
+            <button class="btn btn-secondary btn-small" id="exportPaletteBtn">Export JSON</button>
+          </div>
+        </div>
+
+        <div class="palette-stats" id="paletteStats">
+          <span><strong id="enabledCount">0</strong> blocks enabled</span>
+          <span><strong id="totalCount">0</strong> total blocks</span>
+        </div>
+
+        <div id="paletteBlockList" class="palette-block-list">
+          <!-- Blocks will be dynamically inserted here -->
+        </div>
+
+        <div class="add-block-form">
+          <input type="text" id="newBlockId" placeholder="Block ID (e.g., minecraft:stone)">
+          <input type="color" id="newBlockColor" class="color-input" value="#808080">
+          <button class="btn btn-secondary" id="addBlockBtn">Add Block</button>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" id="resetPaletteBtn">Reset to Default</button>
+        <div class="save-palette-form">
+          <div class="form-group">
+            <input type="text" id="customPaletteName" placeholder="Custom palette name">
+          </div>
+          <button class="btn btn-primary" id="savePaletteBtn">Save as Custom Palette</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Hidden file input for importing palettes -->
+  <input type="file" id="importPaletteInput" accept=".json" style="display: none;">
 
   <script type="module" src="./bundle.js"></script>
 </body>


### PR DESCRIPTION
Add a palette editor modal that allows users to:
- Enable/disable individual blocks in a palette
- Edit block colors via color picker or hex input
- Search/filter blocks by ID
- Add new custom blocks to the palette
- Remove blocks from the palette
- Import palettes from JSON files
- Export customized palettes as JSON
- Save custom palettes to localStorage
- Load and select saved custom palettes from dropdown

The feature includes a modern dark-themed UI consistent with the existing demo design, with responsive layout support.