### PR TITLE
feat: Add mcaddon and VOX file format support to demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -7,7 +7,8 @@
   <script type="importmap">
     {
       "imports": {
-        "nbtify": "https://esm.sh/nbtify@1.90.1"
+        "nbtify": "https://esm.sh/nbtify@1.90.1",
+        "https://esm.sh/jszip@3.10.1": "https://esm.sh/jszip@3.10.1"
       }
     }
   </script>
@@ -588,6 +589,53 @@
       padding: 8px 12px;
       font-size: 0.85rem;
     }
+
+    /* File type buttons */
+    .file-type-buttons {
+      display: flex;
+      gap: 8px;
+      margin-top: 12px;
+      justify-content: center;
+    }
+
+    /* mcaddon options */
+    .mcaddon-options {
+      background: rgba(0, 0, 0, 0.2);
+      border-radius: var(--border-radius);
+      padding: 12px;
+      margin-bottom: 16px;
+    }
+
+    .mcaddon-options .form-group {
+      margin-bottom: 12px;
+    }
+
+    .mcaddon-options .form-group:last-child {
+      margin-bottom: 0;
+    }
+
+    input[type="number"] {
+      width: 100%;
+      padding: 10px 12px;
+      background: var(--accent);
+      border: 1px solid transparent;
+      border-radius: var(--border-radius);
+      color: var(--text);
+      font-size: 1rem;
+      transition: border-color 0.2s;
+    }
+
+    input[type="number"]:focus {
+      outline: none;
+      border-color: var(--highlight);
+    }
+
+    /* Format info tooltip */
+    .format-info {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 4px;
+    }
   </style>
 </head>
 <body>
@@ -603,10 +651,15 @@
         Upload Image
       </h2>
       <div id="dropZone" class="drop-zone">
-        <p>Drop your image here or click to browse</p>
-        <p class="hint">Supports PNG, JPEG, GIF (including animated)</p>
+        <p>Drop your file here or click to browse</p>
+        <p class="hint">Supports PNG, JPEG, GIF (including animated), and VOX files</p>
       </div>
       <input type="file" id="imageInput" accept="image/*">
+      <input type="file" id="voxInput" accept=".vox" style="display: none;">
+      <div class="file-type-buttons">
+        <button type="button" class="btn btn-secondary btn-small" onclick="document.getElementById('imageInput').click()">Select Image</button>
+        <button type="button" class="btn btn-secondary btn-small" onclick="document.getElementById('voxInput').click()">Select VOX</button>
+      </div>
     </div>
 
     <div class="card">
@@ -653,7 +706,24 @@
               <option value="mcfunction">.mcfunction (Commands)</option>
               <option value="nbt">.nbt (Java Edition)</option>
               <option value="schematic">.schematic (Legacy)</option>
+              <option value="mcaddon">.mcaddon (Custom Blocks)</option>
             </select>
+          </div>
+          <div id="mcaddonOptions" class="mcaddon-options" style="display: none;">
+            <div class="form-group">
+              <label for="gridSizeInput">Grid Size (blocks per row)</label>
+              <input type="number" id="gridSizeInput" value="4" min="1" max="32" step="1">
+            </div>
+            <div class="form-group">
+              <label for="resolutionSelect">Texture Resolution</label>
+              <select id="resolutionSelect">
+                <option value="16">16x16 (Default)</option>
+                <option value="32">32x32</option>
+                <option value="64">64x64</option>
+                <option value="128">128x128</option>
+                <option value="256">256x256 (HD)</option>
+              </select>
+            </div>
           </div>
           <div class="form-group">
             <label for="axisSelect">Structure Axis</label>

--- a/src/client/mcaddon.ts
+++ b/src/client/mcaddon.ts
@@ -1,0 +1,487 @@
+/**
+ * Client-side mcaddon conversion for img2mcstructure
+ * Uses browser-native Canvas API and JSZip - no Node.js dependencies
+ *
+ * Creates a Minecraft Bedrock addon that converts an image into a mosaic
+ * using custom blocks with textures sliced from the original image.
+ */
+
+import type {
+  Axis,
+  IMcStructure,
+  StructurePalette,
+} from "../types.ts";
+import { decodeFile, type ImageInput, type DecodeOptions, type DecodedFrames, type ImageFrame } from "./decode.ts";
+import decode from "./decode.ts";
+import { BLOCK_VERSION, BLOCK_FORMAT_VERSION } from "./constants.ts";
+import { rgb2hex } from "./lib.ts";
+
+/**
+ * Options for converting an image to mcaddon
+ */
+export interface McaddonOptions {
+  /** Grid size - number of blocks per row/column */
+  gridSize?: number;
+  /** Resolution of each block texture in pixels */
+  resolution?: number;
+  /** Axis on which to orient the structure */
+  axis?: Axis;
+  /** Decode options */
+  decodeOptions?: DecodeOptions;
+}
+
+/**
+ * Get average color of an ImageData region as hex string
+ */
+function getAverageColor(imageData: ImageData): string {
+  const { data, width, height } = imageData;
+  let r = 0, g = 0, b = 0;
+  const pixelCount = width * height;
+
+  for (let i = 0; i < data.length; i += 4) {
+    r += data[i];
+    g += data[i + 1];
+    b += data[i + 2];
+  }
+
+  return rgb2hex([
+    Math.round(r / pixelCount),
+    Math.round(g / pixelCount),
+    Math.round(b / pixelCount),
+  ]);
+}
+
+/**
+ * Slice an image and return as PNG blob
+ */
+async function sliceImage(
+  img: HTMLImageElement | HTMLCanvasElement,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  targetSize: number,
+): Promise<{ blob: Blob; avgColor: string }> {
+  const canvas = document.createElement("canvas");
+  canvas.width = targetSize;
+  canvas.height = targetSize;
+  const ctx = canvas.getContext("2d")!;
+
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(img, x, y, width, height, 0, 0, targetSize, targetSize);
+
+  const imageData = ctx.getImageData(0, 0, targetSize, targetSize);
+  const avgColor = getAverageColor(imageData);
+
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => {
+      resolve({ blob: blob!, avgColor });
+    }, "image/png");
+  });
+}
+
+/**
+ * Create a block definition JSON for Minecraft Bedrock
+ */
+function createBlockJson(
+  namespace: string,
+  sliceId: string,
+  avgColor: string,
+): string {
+  const data = {
+    format_version: BLOCK_FORMAT_VERSION,
+    "minecraft:block": {
+      description: {
+        identifier: `${namespace}:${sliceId}`,
+        traits: {},
+      },
+      components: {
+        "minecraft:geometry": "minecraft:geometry.full_block",
+        "minecraft:map_color": avgColor,
+        "minecraft:material_instances": {
+          "*": {
+            texture: `${namespace}_${sliceId}`,
+            render_method: "opaque",
+            ambient_occlusion: true,
+            face_dimming: true,
+          },
+        },
+      },
+      permutations: [],
+    },
+  };
+
+  return JSON.stringify(data, null, 2);
+}
+
+/**
+ * Generate a random ID for the addon
+ */
+function generateId(length = 7): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+/**
+ * Rotate volume array based on axis
+ */
+function rotateVolume(volume: number[][][], axis: Axis): number[][][] {
+  const rotatedVolume = volume.map((z) => z.map((y) => y.map(() => -1)));
+
+  const depth = volume.length;
+  const gridSize = volume[0].length;
+
+  for (let z = 0; z < depth; z++) {
+    for (let x = 0; x < gridSize; x++) {
+      for (let y = 0; y < gridSize; y++) {
+        const blockIdx = volume[z][x][y];
+        if (axis === "y") {
+          rotatedVolume[z][y][x] = blockIdx;
+          continue;
+        }
+
+        if (axis === "x") {
+          rotatedVolume[x][z][y] = blockIdx;
+          continue;
+        }
+
+        rotatedVolume[z][x][y] = blockIdx;
+      }
+    }
+  }
+
+  return rotatedVolume;
+}
+
+/**
+ * Load image from File or data
+ */
+async function loadImageElement(input: ImageInput | File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+
+    if (input instanceof File) {
+      const url = URL.createObjectURL(input);
+      img.onload = () => {
+        URL.revokeObjectURL(url);
+        resolve(img);
+      };
+      img.src = url;
+    } else if (typeof input === "string") {
+      // Base64 or data URI
+      img.src = input.startsWith("data:") ? input : `data:image/png;base64,${input}`;
+    } else {
+      // ArrayBuffer or Uint8Array
+      const blob = new Blob([input]);
+      const url = URL.createObjectURL(blob);
+      img.onload = () => {
+        URL.revokeObjectURL(url);
+        resolve(img);
+      };
+      img.src = url;
+    }
+  });
+}
+
+/**
+ * Serialize NBT structure to binary format
+ */
+async function serializeNbt(
+  data: IMcStructure,
+  options: { endian: "little" | "big"; name?: string },
+): Promise<Uint8Array> {
+  const nbt = await import("nbtify");
+  const structure = JSON.stringify(data);
+
+  return await nbt.write(nbt.parse(structure), {
+    // @ts-expect-error - name is not in the type definition
+    name: options.name,
+    endian: options.endian,
+    compression: null,
+    bedrockLevel: false,
+  });
+}
+
+/**
+ * Convert an image to a Minecraft Bedrock addon (.mcaddon)
+ * Creates custom blocks with textures sliced from the image
+ *
+ * @param input Image data (File, ArrayBuffer, Uint8Array, or base64)
+ * @param options Conversion options
+ * @returns .mcaddon file as Uint8Array (ZIP file)
+ *
+ * @example
+ * ```typescript
+ * const file = inputElement.files[0];
+ * const addon = await img2mcaddon(file, {
+ *   gridSize: 4,
+ *   resolution: 16,
+ * });
+ * downloadBlob(addon, 'mosaic.mcaddon');
+ * ```
+ */
+export default async function img2mcaddon(
+  input: ImageInput | File,
+  options: McaddonOptions = {},
+): Promise<Uint8Array> {
+  const {
+    gridSize = 4,
+    resolution = 16,
+    axis = "z",
+  } = options;
+
+  // Dynamic import JSZip
+  const JSZip = (await import("https://esm.sh/jszip@3.10.1")).default;
+
+  const jobId = generateId(7);
+  const addon = new JSZip();
+
+  // Load the image
+  const img = await loadImageElement(input);
+
+  // Get base name for the addon
+  const baseName = input instanceof File
+    ? input.name.replace(/\.[^.]+$/, "")
+    : `mosaic_${jobId}`;
+
+  const namespace = baseName.replace(/\W/g, "_").substring(0, 16).toLowerCase();
+
+  // Calculate crop size
+  const cropSize = Math.min(resolution, Math.round(img.width / gridSize));
+
+  // Resize image to match grid
+  const resizeTo = gridSize * cropSize;
+  const canvas = document.createElement("canvas");
+  canvas.width = resizeTo;
+  canvas.height = resizeTo;
+  const ctx = canvas.getContext("2d")!;
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(img, 0, 0, resizeTo, resizeTo);
+
+  // Data structures
+  const terrainData: Record<string, { textures: string }> = {};
+  const blocksData: Record<string, { sound: string; isotropic: boolean }> = {};
+  const blockPalette: StructurePalette = [];
+
+  const depth = 1;
+  const volume: number[][][] = Array.from(
+    { length: depth },
+    () => Array.from({ length: gridSize }, () => Array(gridSize).fill(-1)),
+  );
+
+  // Process each grid cell
+  for (let x = 0; x < gridSize; x++) {
+    for (let y = 0; y < gridSize; y++) {
+      const sliceId = `${namespace}_${x}_${y}_0`;
+      const xPos = x * cropSize;
+      const yPos = y * cropSize;
+
+      // Slice the image
+      const { blob, avgColor } = await sliceImage(
+        canvas,
+        xPos,
+        yPos,
+        cropSize,
+        cropSize,
+        resolution,
+      );
+
+      // Add block definition
+      addon.file(
+        `bp/blocks/${sliceId}.block.json`,
+        createBlockJson(namespace, sliceId, avgColor),
+      );
+
+      // Add texture
+      addon.file(
+        `rp/textures/blocks/${sliceId}.png`,
+        await blob.arrayBuffer(),
+      );
+
+      // Add texture set
+      addon.file(
+        `rp/textures/blocks/${sliceId}.texture_set.json`,
+        JSON.stringify({
+          format_version: "1.16.100",
+          "minecraft:texture_set": {
+            color: sliceId,
+          },
+        }, null, 2),
+      );
+
+      // Update terrain data
+      terrainData[`${namespace}_${sliceId}`] = {
+        textures: `textures/blocks/${sliceId}`,
+      };
+
+      // Add to block palette
+      const blockIdx = blockPalette.push({
+        name: `${namespace}:${sliceId}`,
+        states: {},
+        version: BLOCK_VERSION,
+      }) - 1;
+
+      volume[0][x][y] = blockIdx;
+
+      // Add blocks.json data
+      blocksData[`${namespace}:${sliceId}`] = {
+        sound: "stone",
+        isotropic: false,
+      };
+    }
+  }
+
+  // Create blocks.json
+  addon.file(
+    "rp/blocks.json",
+    JSON.stringify({
+      format_version: [1, 0, 0],
+      ...blocksData,
+    }, null, 2),
+  );
+
+  // Create terrain_texture.json
+  const mipLevels = {
+    256: 0,
+    128: 1,
+    64: 2,
+    32: 3,
+    16: 4,
+  }[resolution] ?? 0;
+
+  addon.file(
+    "rp/textures/terrain_texture.json",
+    JSON.stringify({
+      resource_pack_name: namespace,
+      texture_name: "atlas.terrain",
+      padding: mipLevels / 2,
+      num_mip_levels: mipLevels,
+      texture_data: terrainData,
+    }, null, 2),
+  );
+
+  // Create and add the structure
+  const rotatedVolume = rotateVolume(volume, axis);
+  const size: [number, number, number] = axis === "y"
+    ? [gridSize, depth, gridSize]
+    : [gridSize, gridSize, depth];
+
+  const flatVolume = rotatedVolume.flat(2);
+  const waterLayer = Array.from({ length: flatVolume.length }, () => -1);
+
+  const tag: IMcStructure = {
+    format_version: 1,
+    size,
+    structure: {
+      block_indices: [flatVolume, waterLayer],
+      entities: [],
+      palette: {
+        default: {
+          block_palette: blockPalette.slice().reverse(),
+          block_position_data: {},
+        },
+      },
+    },
+    structure_world_origin: [0, 0, 0],
+  };
+
+  const mcstructure = await serializeNbt(tag, {
+    endian: "little",
+    name: `${namespace}_${jobId}`,
+  });
+
+  addon.file(`bp/structures/mosaic/${namespace}.mcstructure`, mcstructure);
+
+  // Create pack icon (150x150)
+  const iconCanvas = document.createElement("canvas");
+  iconCanvas.width = 150;
+  iconCanvas.height = 150;
+  const iconCtx = iconCanvas.getContext("2d")!;
+  iconCtx.imageSmoothingEnabled = false;
+  iconCtx.drawImage(img, 0, 0, 150, 150);
+
+  const iconBlob = await new Promise<Blob>((resolve) => {
+    iconCanvas.toBlob((blob) => resolve(blob!), "image/png");
+  });
+  const iconData = await iconBlob.arrayBuffer();
+
+  addon.file("rp/pack_icon.png", iconData);
+  addon.file("bp/pack_icon.png", iconData);
+
+  // Generate UUIDs
+  const rpUuid = crypto.randomUUID();
+  const rpModUuid = crypto.randomUUID();
+  const bpUuid = crypto.randomUUID();
+  const bpModUuid = crypto.randomUUID();
+  const bpVersion = [1, 0, 0];
+  const rpVersion = [1, 0, 0];
+  const minEngineVersion = [1, 21, 2];
+
+  // Create resource pack manifest
+  addon.file(
+    "rp/manifest.json",
+    JSON.stringify({
+      format_version: 2,
+      header: {
+        name: `Mosaic Resources: "${baseName}"`,
+        description: `A mosaic made from an image\n(${jobId})`,
+        uuid: rpUuid,
+        version: rpVersion,
+        min_engine_version: minEngineVersion,
+      },
+      modules: [{
+        description: "Mosaic block textures",
+        type: "resources",
+        uuid: rpModUuid,
+        version: rpVersion,
+      }],
+      dependencies: [{
+        uuid: bpUuid,
+        version: bpVersion,
+      }],
+    }, null, 2),
+  );
+
+  // Create behavior pack manifest
+  addon.file(
+    "bp/manifest.json",
+    JSON.stringify({
+      format_version: 2,
+      header: {
+        name: `Mosaic Blocks: "${baseName}"`,
+        description: `A mosaic made from an image\n(${jobId})`,
+        uuid: bpUuid,
+        version: bpVersion,
+        min_engine_version: minEngineVersion,
+      },
+      modules: [{
+        description: "Mosaic block slices",
+        type: "data",
+        uuid: bpModUuid,
+        version: bpVersion,
+      }],
+      dependencies: [{
+        uuid: rpUuid,
+        version: rpVersion,
+      }],
+    }, null, 2),
+  );
+
+  return await addon.generateAsync({ type: "uint8array" });
+}
+
+/**
+ * Convert a File to mcaddon (convenience wrapper)
+ */
+export async function fileToMcaddon(
+  file: File,
+  options: McaddonOptions = {},
+): Promise<Uint8Array> {
+  return img2mcaddon(file, options);
+}

--- a/src/client/mod.ts
+++ b/src/client/mod.ts
@@ -29,6 +29,8 @@ export { default as img2mcstructure, fileToMcstructure, createMcStructure, const
 export { default as img2mcfunction, fileToMcfunction, framesToMcfunction } from "./mcfunction.ts";
 export { default as img2schematic, fileToSchematic, createSchematic, constructDecoded as constructSchematic } from "./schematic.ts";
 export { default as img2nbt, fileToNbt, createNbtStructure, constructDecoded as constructNbt } from "./nbt.ts";
+export { default as img2mcaddon, fileToMcaddon } from "./mcaddon.ts";
+export { default as vox2mcstructure, fileToVoxMcstructure, parseVox, getVoxInfo, constructDecoded as constructVox } from "./vox.ts";
 
 // Image decoding
 export { default as decode, decodeFile, decodeUrl, colorToRGBA, type ImageInput, type DecodeOptions, type DecodedFrames, type ImageFrame } from "./decode.ts";
@@ -76,6 +78,8 @@ export type { ConvertOptions } from "./mcstructure.ts";
 export type { McfunctionOptions } from "./mcfunction.ts";
 export type { SchematicOptions } from "./schematic.ts";
 export type { NbtOptions } from "./nbt.ts";
+export type { McaddonOptions } from "./mcaddon.ts";
+export type { VoxOptions } from "./vox.ts";
 
 /**
  * Helper to download generated data as a file
@@ -125,4 +129,11 @@ export function downloadSchematic(data: Uint8Array, filename = "structure.schema
  */
 export function downloadNbt(data: Uint8Array, filename = "structure.nbt"): void {
   downloadBlob(data, filename);
+}
+
+/**
+ * Helper to download mcaddon data
+ */
+export function downloadMcaddon(data: Uint8Array, filename = "addon.mcaddon"): void {
+  downloadBlob(data, filename, "application/zip");
 }

--- a/src/client/vox.ts
+++ b/src/client/vox.ts
@@ -1,0 +1,403 @@
+/**
+ * Client-side VOX file conversion for img2mcstructure
+ * Browser-compatible VOX parser and converter to mcstructure
+ */
+
+import type {
+  IBlock,
+  IMcStructure,
+  PaletteSource,
+  StructurePalette,
+} from "../types.ts";
+import createPalette from "./palette.ts";
+import { BLOCK_VERSION, DEFAULT_BLOCK, MASK_BLOCK } from "./constants.ts";
+import { compareStates, getNearestColor } from "./lib.ts";
+
+/**
+ * VOX file data structure
+ */
+interface VoxData {
+  size: { x: number; y: number; z: number };
+  voxels: Array<{ x: number; y: number; z: number; colorIndex: number }>;
+  palette: Array<{ r: number; g: number; b: number; a: number }>;
+}
+
+/**
+ * Options for converting VOX to mcstructure
+ */
+export interface VoxOptions {
+  /** Block palette source (JSON object or IBlock array) */
+  palette: PaletteSource | IBlock[];
+}
+
+/**
+ * Read a little-endian 32-bit integer from a DataView
+ */
+function readInt32(view: DataView, offset: number): number {
+  return view.getInt32(offset, true);
+}
+
+/**
+ * Read a string from a DataView
+ */
+function readString(view: DataView, offset: number, length: number): string {
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += String.fromCharCode(view.getUint8(offset + i));
+  }
+  return result;
+}
+
+/**
+ * Default MagicaVoxel palette
+ */
+const DEFAULT_VOX_PALETTE: Array<{ r: number; g: number; b: number; a: number }> = [
+  { r: 0, g: 0, b: 0, a: 0 }, // Index 0 is unused
+  ...Array.from({ length: 255 }, (_, i) => {
+    // Generate a default palette similar to MagicaVoxel's default
+    const hue = (i * 137.5) % 360;
+    const sat = 0.7 + (i % 10) * 0.03;
+    const val = 0.8 + (i % 5) * 0.04;
+
+    // HSV to RGB conversion
+    const c = val * sat;
+    const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+    const m = val - c;
+
+    let r = 0, g = 0, b = 0;
+    if (hue < 60) { r = c; g = x; }
+    else if (hue < 120) { r = x; g = c; }
+    else if (hue < 180) { g = c; b = x; }
+    else if (hue < 240) { g = x; b = c; }
+    else if (hue < 300) { r = x; b = c; }
+    else { r = c; b = x; }
+
+    return {
+      r: Math.round((r + m) * 255),
+      g: Math.round((g + m) * 255),
+      b: Math.round((b + m) * 255),
+      a: 255,
+    };
+  }),
+];
+
+/**
+ * Parse a VOX file
+ * @param data ArrayBuffer containing VOX file data
+ * @returns Parsed VOX data
+ */
+export function parseVox(data: ArrayBuffer): VoxData {
+  const view = new DataView(data);
+  let offset = 0;
+
+  // Check magic number "VOX "
+  const magic = readString(view, offset, 4);
+  if (magic !== "VOX ") {
+    throw new Error("Invalid VOX file: bad magic number");
+  }
+  offset += 4;
+
+  // Read version
+  const version = readInt32(view, offset);
+  if (version !== 150 && version !== 200) {
+    console.warn(`VOX version ${version} may not be fully supported`);
+  }
+  offset += 4;
+
+  const result: VoxData = {
+    size: { x: 0, y: 0, z: 0 },
+    voxels: [],
+    palette: [...DEFAULT_VOX_PALETTE],
+  };
+
+  // Parse chunks
+  while (offset < data.byteLength) {
+    const chunkId = readString(view, offset, 4);
+    offset += 4;
+
+    const contentSize = readInt32(view, offset);
+    offset += 4;
+
+    const childrenSize = readInt32(view, offset);
+    offset += 4;
+
+    const contentEnd = offset + contentSize;
+
+    switch (chunkId) {
+      case "MAIN":
+        // Main chunk, just continue to children
+        break;
+
+      case "SIZE":
+        result.size.x = readInt32(view, offset);
+        result.size.y = readInt32(view, offset + 4);
+        result.size.z = readInt32(view, offset + 8);
+        break;
+
+      case "XYZI": {
+        const numVoxels = readInt32(view, offset);
+        let voxelOffset = offset + 4;
+
+        for (let i = 0; i < numVoxels; i++) {
+          const x = view.getUint8(voxelOffset);
+          const y = view.getUint8(voxelOffset + 1);
+          const z = view.getUint8(voxelOffset + 2);
+          const colorIndex = view.getUint8(voxelOffset + 3);
+
+          result.voxels.push({ x, y, z, colorIndex });
+          voxelOffset += 4;
+        }
+        break;
+      }
+
+      case "RGBA": {
+        // Custom palette
+        for (let i = 0; i < 255; i++) {
+          const paletteOffset = offset + i * 4;
+          result.palette[i + 1] = {
+            r: view.getUint8(paletteOffset),
+            g: view.getUint8(paletteOffset + 1),
+            b: view.getUint8(paletteOffset + 2),
+            a: view.getUint8(paletteOffset + 3),
+          };
+        }
+        break;
+      }
+
+      // Skip other chunks (nTRN, nGRP, nSHP, LAYR, MATL, etc.)
+      default:
+        break;
+    }
+
+    offset = contentEnd + childrenSize;
+  }
+
+  return result;
+}
+
+/**
+ * Get the appropriate block for the given pixel color.
+ */
+function convertBlock(
+  c: { r: number; g: number; b: number; a: number },
+  palette: IBlock[],
+): Pick<IBlock, "id" | "states" | "version"> {
+  if (c.a < 128) {
+    return {
+      id: MASK_BLOCK,
+      states: {},
+      version: BLOCK_VERSION,
+    };
+  }
+
+  const nearestBlock = getNearestColor([c.r, c.g, c.b], palette);
+
+  if (!nearestBlock) {
+    return {
+      id: DEFAULT_BLOCK,
+      states: {},
+      version: BLOCK_VERSION,
+    };
+  }
+
+  return {
+    id: nearestBlock.id,
+    states: nearestBlock.states ?? {},
+    version: nearestBlock.version ?? BLOCK_VERSION,
+  };
+}
+
+/**
+ * Find or create a block in the structure palette
+ */
+function findBlock(
+  c: { r: number; g: number; b: number; a: number },
+  palette: IBlock[],
+  blockPalette: StructurePalette,
+): [Pick<IBlock, "id" | "states" | "version">, number] {
+  const nearest = convertBlock(c, palette);
+  const blockIdx = blockPalette.findIndex(
+    ({ name, states }) =>
+      name === nearest.id && compareStates(nearest.states, states),
+  );
+
+  return [nearest, blockIdx];
+}
+
+/**
+ * Construct mcstructure data from parsed VOX
+ */
+export function constructDecoded(
+  vox: VoxData,
+  palette: IBlock[],
+): IMcStructure {
+  const blockPalette: StructurePalette = [];
+
+  // VOX uses different coordinate system, convert to Minecraft
+  const size: [number, number, number] = [vox.size.x, vox.size.z, vox.size.y];
+  const [width, height, depth] = size;
+
+  const memo = new Map<
+    number,
+    [Pick<IBlock, "states" | "version" | "id">, number]
+  >();
+
+  const layer = Array.from({ length: width * height * depth }, () => -1);
+  const waterLayer = layer.slice();
+
+  for (const voxel of vox.voxels) {
+    const color = vox.palette[voxel.colorIndex];
+    if (!color || color.a < 128) continue;
+
+    let [nearest, blockIdx] = memo.get(voxel.colorIndex) ??
+      findBlock(color, palette, blockPalette);
+
+    if (blockIdx === -1) {
+      blockIdx = blockPalette.push({
+        version: nearest.version ?? BLOCK_VERSION,
+        name: nearest.id ?? DEFAULT_BLOCK,
+        states: nearest.states ?? {},
+      }) - 1;
+
+      memo.set(voxel.colorIndex, [nearest, blockIdx]);
+    }
+
+    // Convert VOX coordinates to Minecraft structure coordinates
+    const x = voxel.x;
+    const y = vox.size.z - 1 - voxel.z; // Flip Z to Y
+    const z = voxel.y; // Swap Y and Z
+
+    const key = (y * width + x) * depth + z;
+
+    if (key >= 0 && key < layer.length) {
+      layer[key] = blockIdx;
+    }
+  }
+
+  // Filter out empty indices
+  const filteredLayer = layer.map((i) => (i === -1 ? -1 : i));
+
+  const tag: IMcStructure = {
+    format_version: 1,
+    size,
+    structure_world_origin: [0, 0, 0],
+    structure: {
+      block_indices: [filteredLayer, waterLayer],
+      entities: [],
+      palette: {
+        default: {
+          block_palette: blockPalette,
+          block_position_data: {},
+        },
+      },
+    },
+  };
+
+  return tag;
+}
+
+/**
+ * Serialize NBT structure to binary format
+ */
+async function serializeNbt(
+  data: IMcStructure,
+  options: { endian: "little" | "big"; name?: string },
+): Promise<Uint8Array> {
+  const nbt = await import("nbtify");
+  const structure = JSON.stringify(data);
+
+  return await nbt.write(nbt.parse(structure), {
+    // @ts-expect-error - name is not in the type definition
+    name: options.name,
+    endian: options.endian,
+    compression: null,
+    bedrockLevel: false,
+  });
+}
+
+/**
+ * Convert a VOX file to a Minecraft Bedrock structure file.
+ * @param input VOX file data (File, ArrayBuffer, or Uint8Array)
+ * @param options Conversion options
+ * @returns .mcstructure data as Uint8Array
+ *
+ * @example
+ * ```typescript
+ * import { vox2mcstructure } from './client/mod.ts';
+ *
+ * const file = inputElement.files[0];
+ * const structure = await vox2mcstructure(file, {
+ *   palette: minecraftPalette
+ * });
+ * downloadMcstructure(structure, 'model.mcstructure');
+ * ```
+ */
+export default async function vox2mcstructure(
+  input: File | ArrayBuffer | Uint8Array,
+  options: VoxOptions,
+): Promise<Uint8Array> {
+  const { palette } = options;
+
+  // Get ArrayBuffer from input
+  let buffer: ArrayBuffer;
+  if (input instanceof File) {
+    buffer = await input.arrayBuffer();
+  } else if (input instanceof Uint8Array) {
+    buffer = input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength);
+  } else {
+    buffer = input;
+  }
+
+  // Parse VOX file
+  const vox = parseVox(buffer);
+
+  // Create palette if needed
+  const blockPalette = Array.isArray(palette) ? palette : createPalette(palette);
+
+  // Construct the structure
+  const structure = constructDecoded(vox, blockPalette);
+
+  // Serialize to NBT
+  return await serializeNbt(structure, {
+    endian: "little",
+    name: "vox2mcstructure",
+  });
+}
+
+/**
+ * Convert a File to mcstructure (convenience wrapper)
+ */
+export async function fileToVoxMcstructure(
+  file: File,
+  options: VoxOptions,
+): Promise<Uint8Array> {
+  return vox2mcstructure(file, options);
+}
+
+/**
+ * Get information about a VOX file without converting
+ */
+export async function getVoxInfo(
+  input: File | ArrayBuffer | Uint8Array,
+): Promise<{
+  size: { x: number; y: number; z: number };
+  voxelCount: number;
+  paletteSize: number;
+}> {
+  let buffer: ArrayBuffer;
+  if (input instanceof File) {
+    buffer = await input.arrayBuffer();
+  } else if (input instanceof Uint8Array) {
+    buffer = input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength);
+  } else {
+    buffer = input;
+  }
+
+  const vox = parseVox(buffer);
+
+  return {
+    size: vox.size,
+    voxelCount: vox.voxels.length,
+    paletteSize: vox.palette.filter((c) => c.a > 0).length,
+  };
+}


### PR DESCRIPTION
- Add browser-compatible mcaddon converter (creates Minecraft addons with custom blocks and textures sliced from images)
- Add browser-compatible VOX file parser and converter (MagicaVoxel format)
- Update demo UI with new format options:
  - mcaddon format with grid size and texture resolution options
  - VOX file input support with drag-and-drop
- Add downloadMcaddon helper function
- Export new conversion functions from client module