### PR TITLE
fix: preserve image aspect ratio in mcaddon conversion

### DIFF
--- a/src/mcaddon/mod.ts
+++ b/src/mcaddon/mod.ts
@@ -17,7 +17,8 @@ function getAverageColor(image: imagescript.Image): string {
 function createBlock({
   namespace,
   image,
-  gridSize,
+  gridSizeX,
+  gridSizeY,
   x,
   y,
   z = 1,
@@ -25,7 +26,8 @@ function createBlock({
 }: {
   namespace: string;
   image: imagescript.Image;
-  gridSize: number;
+  gridSizeX: number;
+  gridSizeY: number;
   x: number;
   y: number;
   z: number;
@@ -33,16 +35,16 @@ function createBlock({
 }): string {
   const sliceId = {
     front: `${namespace}_${x}_${y}_${z}`,
-    back: `${namespace}_${gridSize - x - 1}_${y}_${z}`,
-    top: `${namespace}_${x}_${gridSize - y - 1}_${z}`,
+    back: `${namespace}_${gridSizeX - x - 1}_${y}_${z}`,
+    top: `${namespace}_${x}_${gridSizeY - y - 1}_${z}`,
     bottom: `${namespace}_${x}_${y}_${z}`,
   };
 
   if (axis === "y") {
-    sliceId.front = `${namespace}_${x}_${z}_${gridSize - y - 1}`;
-    sliceId.back = `${namespace}_${gridSize - x - 1}_${z}_${gridSize - y - 1}`;
+    sliceId.front = `${namespace}_${x}_${z}_${gridSizeY - y - 1}`;
+    sliceId.back = `${namespace}_${gridSizeX - x - 1}_${z}_${gridSizeY - y - 1}`;
     sliceId.top = `${namespace}_${x}_${z}_${y}`;
-    sliceId.bottom = `${namespace}_${x}_${z}_${gridSize - y - 1}`;
+    sliceId.bottom = `${namespace}_${x}_${z}_${gridSizeY - y - 1}`;
   }
 
   const data = {
@@ -113,14 +115,29 @@ function createBlock({
 
 // TODO: Refactor function. It is redundant with rotateStructure function
 function rotateVolume(volume: number[][][], axis: Axis): number[][][] {
-  const rotatedVolume = volume.map((z) => z.map((y) => y.map(() => -1)));
-
   const depth = volume.length;
-  const gridSize = volume[0].length;
+  const gridSizeX = volume[0].length;
+  const gridSizeY = volume[0][0].length;
+
+  // Create rotated volume with appropriate dimensions based on axis
+  let rotatedVolume: number[][][];
+  if (axis === "y") {
+    rotatedVolume = Array.from({ length: depth }, () =>
+      Array.from({ length: gridSizeY }, () => Array(gridSizeX).fill(-1))
+    );
+  } else if (axis === "x") {
+    rotatedVolume = Array.from({ length: gridSizeX }, () =>
+      Array.from({ length: depth }, () => Array(gridSizeY).fill(-1))
+    );
+  } else {
+    rotatedVolume = Array.from({ length: depth }, () =>
+      Array.from({ length: gridSizeX }, () => Array(gridSizeY).fill(-1))
+    );
+  }
 
   for (let z = 0; z < depth; z++) {
-    for (let x = 0; x < gridSize; x++) {
-      for (let y = 0; y < gridSize; y++) {
+    for (let x = 0; x < gridSizeX; x++) {
+      for (let y = 0; y < gridSizeY; y++) {
         const blockIdx = volume[z][x][y];
         if (axis === "y") {
           rotatedVolume[z][y][x] = blockIdx;
@@ -150,8 +167,10 @@ async function iterateDepth({
   merTexture,
   normalTexture,
   frames,
-  gridSize,
-  cropSize,
+  gridSizeX,
+  gridSizeY,
+  cropSizeX,
+  cropSizeY,
   depth,
   pbr,
 }: {
@@ -164,30 +183,34 @@ async function iterateDepth({
   merTexture: DecodedFrames;
   normalTexture: DecodedFrames;
   frames: DecodedFrames;
-  gridSize: number;
-  cropSize: number;
+  gridSizeX: number;
+  gridSizeY: number;
+  cropSizeX: number;
+  cropSizeY: number;
   depth: number;
   pbr: boolean;
 }) {
   for (let z = 0; z < depth; z++) {
-    const resizeTo = gridSize * cropSize;
+    const resizeToX = gridSizeX * cropSizeX;
+    const resizeToY = gridSizeY * cropSizeY;
     const frame: imagescript.Image = (
       frames[z].clone() as imagescript.Image
-    ).resize(resizeTo, resizeTo);
+    ).resize(resizeToX, resizeToY);
 
-    for (let x = 0; x < gridSize; x++) {
-      for (let y = 0; y < gridSize; y++) {
+    for (let x = 0; x < gridSizeX; x++) {
+      for (let y = 0; y < gridSizeY; y++) {
         const sliceId = `${namespace}_${x}_${y}_${z}`;
-        const xPos = x * cropSize;
-        const yPos = y * cropSize;
-        const slice = frame.clone().crop(xPos, yPos, cropSize, cropSize);
+        const xPos = x * cropSizeX;
+        const yPos = y * cropSizeY;
+        const slice = frame.clone().crop(xPos, yPos, cropSizeX, cropSizeY);
 
         addon.file(
           `bp/blocks/${sliceId}.block.json`,
           createBlock({
             namespace,
             image: slice,
-            gridSize,
+            gridSizeX,
+            gridSizeY,
             x,
             y,
             z,
@@ -210,8 +233,8 @@ async function iterateDepth({
               `rp/textures/blocks/${sliceId}_mer.png`,
               await merTexture[z]
                 .clone()
-                .resize(resizeTo, resizeTo)
-                .crop(xPos, yPos, cropSize, cropSize)
+                .resize(resizeToX, resizeToY)
+                .crop(xPos, yPos, cropSizeX, cropSizeY)
                 .encode(),
             );
             textureSet.metalness_emissive_roughness = `${sliceId}_mer`;
@@ -224,8 +247,8 @@ async function iterateDepth({
               `rp/textures/blocks/${sliceId}_normal.png`,
               await normalTexture[z]
                 .clone()
-                .resize(resizeTo, resizeTo)
-                .crop(xPos, yPos, cropSize, cropSize)
+                .resize(resizeToX, resizeToY)
+                .crop(xPos, yPos, cropSizeX, cropSizeY)
                 .encode(),
             );
             textureSet.normal = `${sliceId}_normal`;
@@ -289,8 +312,10 @@ async function createFlipbook({
   merTexture,
   normalTexture,
   frames,
-  gridSize,
-  cropSize,
+  gridSizeX,
+  gridSizeY,
+  cropSizeX,
+  cropSizeY,
   pbr,
   axis,
 }: {
@@ -303,8 +328,10 @@ async function createFlipbook({
   merTexture: DecodedFrames;
   normalTexture: DecodedFrames;
   frames: DecodedFrames;
-  gridSize: number;
-  cropSize: number;
+  gridSizeX: number;
+  gridSizeY: number;
+  cropSizeX: number;
+  cropSizeY: number;
   pbr: boolean;
   axis: Axis;
 }) {
@@ -317,15 +344,15 @@ async function createFlipbook({
 
   const tickSpeed = 10;
 
-  for (let x = 0; x < gridSize; x++) {
-    for (let y = 0; y < gridSize; y++) {
+  for (let x = 0; x < gridSizeX; x++) {
+    for (let y = 0; y < gridSizeY; y++) {
       const sliceId = `${namespace}_${x}_${y}_1`;
 
       const flatFrames: imagescript.Image[] = frames.flat();
 
       const slice = await series2atlas(
         flatFrames.map((frame) =>
-          frame.clone().crop(x * cropSize, y * cropSize, cropSize, cropSize)
+          frame.clone().crop(x * cropSizeX, y * cropSizeY, cropSizeX, cropSizeY)
         ),
       );
 
@@ -334,7 +361,8 @@ async function createFlipbook({
         createBlock({
           namespace,
           image: slice,
-          gridSize,
+          gridSizeX,
+          gridSizeY,
           x,
           y,
           z: 1,
@@ -362,7 +390,7 @@ async function createFlipbook({
                 flatMerFrames.map((frame: imagescript.Image) =>
                   frame
                     .clone()
-                    .crop(x * cropSize, y * cropSize, cropSize, cropSize)
+                    .crop(x * cropSizeX, y * cropSizeY, cropSizeX, cropSizeY)
                 ),
               )
             ).encode(),
@@ -381,7 +409,7 @@ async function createFlipbook({
                 flatNormalFrames.map((frame: imagescript.Image) =>
                   frame
                     .clone()
-                    .crop(x * cropSize, y * cropSize, cropSize, cropSize)
+                    .crop(x * cropSizeX, y * cropSizeY, cropSizeX, cropSizeY)
                 ),
               )
             ).encode(),
@@ -541,14 +569,22 @@ export default async function img2mcaddon(
 
   const depth = frames > 1 ? 1 : decodedFrames.length;
 
+  // Calculate grid dimensions based on image aspect ratio
+  const imageWidth = decodedFrames[0].width;
+  const imageHeight = decodedFrames[0].height;
+  const aspectRatio = imageHeight / imageWidth;
+
+  // gridSize is used for the X dimension, calculate Y based on aspect ratio
+  const gridSizeX = gridSize;
+  const gridSizeY = Math.max(1, Math.round(gridSize * aspectRatio));
+
+  // Calculate crop sizes for each dimension
+  const cropSizeX = Math.min(resolution, Math.round(imageWidth / gridSizeX));
+  const cropSizeY = Math.min(resolution, Math.round(imageHeight / gridSizeY));
+
   const volume: number[][][] = Array.from(
     { length: depth },
-    () => Array.from({ length: gridSize }, () => Array(gridSize).fill(-1)),
-  );
-
-  const cropSize = Math.min(
-    resolution,
-    Math.round(decodedFrames[0].width / gridSize),
+    () => Array.from({ length: gridSizeX }, () => Array(gridSizeY).fill(-1)),
   );
 
   let flipbookVolume: number[][][] | undefined;
@@ -556,7 +592,7 @@ export default async function img2mcaddon(
   if (frames > 1) {
     flipbookVolume = Array.from(
       { length: 1 },
-      () => Array.from({ length: gridSize }, () => Array(gridSize).fill(-1)),
+      () => Array.from({ length: gridSizeX }, () => Array(gridSizeY).fill(-1)),
     );
 
     await createFlipbook({
@@ -569,8 +605,10 @@ export default async function img2mcaddon(
       merTexture,
       normalTexture,
       frames: decodedFrames,
-      gridSize,
-      cropSize,
+      gridSizeX,
+      gridSizeY,
+      cropSizeX,
+      cropSizeY,
       pbr,
       axis,
     });
@@ -585,8 +623,10 @@ export default async function img2mcaddon(
       merTexture,
       normalTexture,
       frames: decodedFrames,
-      gridSize,
-      cropSize,
+      gridSizeX,
+      gridSizeY,
+      cropSizeX,
+      cropSizeY,
       depth,
       pbr,
     });
@@ -594,8 +634,8 @@ export default async function img2mcaddon(
 
   const rotatedVolume = rotateVolume(flipbookVolume ?? volume, axis);
   const size: [number, number, number] = axis === "y"
-    ? [gridSize, depth, gridSize]
-    : [gridSize, gridSize, depth];
+    ? [gridSizeX, depth, gridSizeY]
+    : [gridSizeX, gridSizeY, depth];
 
   const flatVolume = rotatedVolume.flat(2);
   const waterLayer = Array.from({ length: flatVolume.length }, () => -1);


### PR DESCRIPTION
The mcaddon conversion was forcing input images into a square grid, distorting non-square images. This change calculates separate grid dimensions (gridSizeX/gridSizeY) and crop sizes (cropSizeX/cropSizeY) based on the image's aspect ratio, preserving the original proportions.

Changes:
- Calculate gridSizeY based on image aspect ratio (height/width)
- Use separate crop sizes for X and Y dimensions
- Update rotateVolume to handle non-square grids correctly
- Update iterateDepth and createFlipbook functions with new parameters
- Fix structure size calculation to use correct dimensions
- Apply same fix to both server-side and client-side implementations