### PR TITLE
fix: use full ESM URL for nbtify in service worker

### DIFF
--- a/demo/worker.bundle.js
+++ b/demo/worker.bundle.js
@@ -357,7 +357,7 @@ function parseVox(data) {
   return result;
 }
 async function serializeNbt(data, options) {
-  const nbt = await import("nbtify");
+  const nbt = await import("https://esm.sh/nbtify@1.90.1");
   const structure = JSON.stringify(data);
   return await nbt.write(nbt.parse(structure), {
     name: options.name,

--- a/src/client/worker.ts
+++ b/src/client/worker.ts
@@ -536,7 +536,8 @@ async function serializeNbt(
   data: object,
   options: { endian: "little" | "big"; name?: string }
 ): Promise<Uint8Array> {
-  const nbt = await import("nbtify");
+  // Use full ESM URL since workers don't have access to import maps
+  const nbt = await import("https://esm.sh/nbtify@1.90.1");
   const structure = JSON.stringify(data);
 
   return await nbt.write(nbt.parse(structure), {


### PR DESCRIPTION
Service workers don't have access to import maps defined in the main HTML document, causing "Failed to resolve module specifier 'nbtify'" errors. Changed the dynamic import to use the full esm.sh URL instead of the bare module specifier, matching the pattern used for gifuct-js.