### PR TITLE
fix: validate GIF frame patch size before creating ImageData

### DIFF
--- a/demo/bundle.js
+++ b/demo/bundle.js
@@ -104,7 +104,18 @@ async function decodeGif(data, options = {}) {
     if (disposalType === 3) {
       previousImageData = ctx.getImageData(0, 0, gifWidth, gifHeight);
     }
-    const frameImageData = new ImageData(new Uint8ClampedArray(patch), dims.width, dims.height);
+    const expectedSize = dims.width * dims.height * 4;
+    let frameData;
+    if (patch.length === expectedSize) {
+      frameData = new Uint8ClampedArray(patch);
+    } else {
+      frameData = new Uint8ClampedArray(expectedSize);
+      frameData.set(patch.subarray(0, Math.min(patch.length, expectedSize)));
+    }
+    if (dims.width <= 0 || dims.height <= 0) {
+      continue;
+    }
+    const frameImageData = new ImageData(frameData, dims.width, dims.height);
     ctx.putImageData(frameImageData, dims.left, dims.top);
     let finalImageData = ctx.getImageData(0, 0, gifWidth, gifHeight);
     if (options.clamp) {

--- a/demo/worker.bundle.js
+++ b/demo/worker.bundle.js
@@ -393,7 +393,18 @@ async function decodeImageInWorker(data, options = {}) {
       if (disposalType === 3) {
         previousImageData = ctx2.getImageData(0, 0, gifWidth, gifHeight);
       }
-      const frameImageData = new ImageData(new Uint8ClampedArray(patch), dims.width, dims.height);
+      const expectedSize = dims.width * dims.height * 4;
+      let frameData;
+      if (patch.length === expectedSize) {
+        frameData = new Uint8ClampedArray(patch);
+      } else {
+        frameData = new Uint8ClampedArray(expectedSize);
+        frameData.set(patch.subarray(0, Math.min(patch.length, expectedSize)));
+      }
+      if (dims.width <= 0 || dims.height <= 0) {
+        continue;
+      }
+      const frameImageData = new ImageData(frameData, dims.width, dims.height);
       ctx2.putImageData(frameImageData, dims.left, dims.top);
       let finalImageData = ctx2.getImageData(0, 0, gifWidth, gifHeight);
       if (options.clamp) {

--- a/src/client/decode.ts
+++ b/src/client/decode.ts
@@ -176,11 +176,24 @@ async function decodeGif(
     }
 
     // Create ImageData from the frame patch
-    const frameImageData = new ImageData(
-      new Uint8ClampedArray(patch),
-      dims.width,
-      dims.height,
-    );
+    // Validate patch size matches expected dimensions to avoid "Invalid array length" errors
+    const expectedSize = dims.width * dims.height * 4;
+    let frameData: Uint8ClampedArray;
+
+    if (patch.length === expectedSize) {
+      frameData = new Uint8ClampedArray(patch);
+    } else {
+      // Patch size doesn't match - create properly sized array and copy available data
+      frameData = new Uint8ClampedArray(expectedSize);
+      frameData.set(patch.subarray(0, Math.min(patch.length, expectedSize)));
+    }
+
+    // Skip frames with invalid dimensions
+    if (dims.width <= 0 || dims.height <= 0) {
+      continue;
+    }
+
+    const frameImageData = new ImageData(frameData, dims.width, dims.height);
 
     // Draw the frame patch at its position
     ctx.putImageData(frameImageData, dims.left, dims.top);

--- a/src/client/worker.ts
+++ b/src/client/worker.ts
@@ -616,11 +616,24 @@ async function decodeImageInWorker(
         previousImageData = ctx.getImageData(0, 0, gifWidth, gifHeight);
       }
 
-      const frameImageData = new ImageData(
-        new Uint8ClampedArray(patch),
-        dims.width,
-        dims.height
-      );
+      // Validate patch size matches expected dimensions to avoid "Invalid array length" errors
+      const expectedSize = dims.width * dims.height * 4;
+      let frameData: Uint8ClampedArray;
+
+      if (patch.length === expectedSize) {
+        frameData = new Uint8ClampedArray(patch);
+      } else {
+        // Patch size doesn't match - create properly sized array and copy available data
+        frameData = new Uint8ClampedArray(expectedSize);
+        frameData.set(patch.subarray(0, Math.min(patch.length, expectedSize)));
+      }
+
+      // Skip frames with invalid dimensions
+      if (dims.width <= 0 || dims.height <= 0) {
+        continue;
+      }
+
+      const frameImageData = new ImageData(frameData, dims.width, dims.height);
 
       ctx.putImageData(frameImageData, dims.left, dims.top);
 


### PR DESCRIPTION
Fixes "Invalid array length" error when decoding certain GIF files. The gifuct-js library's patch data may not always match the expected size (dims.width * dims.height * 4) due to GIF optimizations or malformed frames. This change validates the patch size and creates properly sized arrays when needed, and skips frames with invalid dimensions.