### PR TITLE
Add support for RGB block mod v2

### DIFF
--- a/db/rgbscreen.json
+++ b/db/rgbscreen.json
@@ -1,0 +1,42 @@
+[
+  {
+    "index": 0,
+    "color": [255, 255, 255],
+    "hexColor": "#ffffff"
+  },
+  {
+    "index": 1,
+    "color": [255, 0, 0],
+    "hexColor": "#ff0000"
+  },
+  {
+    "index": 2,
+    "color": [0, 255, 0],
+    "hexColor": "#00ff00"
+  },
+  {
+    "index": 3,
+    "color": [0, 0, 255],
+    "hexColor": "#0000ff"
+  },
+  {
+    "index": 4,
+    "color": [255, 255, 0],
+    "hexColor": "#ffff00"
+  },
+  {
+    "index": 5,
+    "color": [0, 255, 255],
+    "hexColor": "#00ffff"
+  },
+  {
+    "index": 6,
+    "color": [255, 0, 255],
+    "hexColor": "#ff00ff"
+  },
+  {
+    "index": 7,
+    "color": [0, 0, 0],
+    "hexColor": "#000000"
+  }
+]

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,7 @@
 export { default as img2schematic } from "./src/schematic/mod.ts";
 export { default as img2mcstructure } from "./src/mcstructure/mod.ts";
 export { default as img2nbt } from "./src/nbt/mod.ts";
+export { default as img2rgbscreen } from "./src/nbt/rgbscreen.ts";
 export { default as vox2mcstructure, vox2gif } from "./src/vox/mod.ts";
 export { default as img2mcaddon } from "./src/mcaddon/mod.ts";
 export { default as img2mcfunction } from "./src/mcfunction/mod.ts";

--- a/src/_constants.ts
+++ b/src/_constants.ts
@@ -11,6 +11,11 @@ export const BLOCK_VERSION = 18153475;
 export const NBT_DATA_VERSION = 3953;
 
 /**
+ * RGB Screen NBT data version (Minecraft 1.21+).
+ */
+export const RGBSCREEN_DATA_VERSION = 4556;
+
+/**
  * Minecraft behavior block format version.
  */
 export const BLOCK_FORMAT_VERSION = "1.20.80";

--- a/src/client/constants.ts
+++ b/src/client/constants.ts
@@ -14,6 +14,11 @@ export const BLOCK_VERSION = 18153475;
 export const NBT_DATA_VERSION = 3953;
 
 /**
+ * RGB Screen NBT data version (Minecraft 1.21+).
+ */
+export const RGBSCREEN_DATA_VERSION = 4556;
+
+/**
  * Minecraft behavior block format version.
  */
 export const BLOCK_FORMAT_VERSION = "1.20.80";

--- a/src/client/mod.ts
+++ b/src/client/mod.ts
@@ -46,6 +46,7 @@ export { default as img2mcstructure, fileToMcstructure, createMcStructure, const
 export { default as img2mcfunction, fileToMcfunction, framesToMcfunction } from "./mcfunction.ts";
 export { default as img2schematic, fileToSchematic, createSchematic, constructDecoded as constructSchematic } from "./schematic.ts";
 export { default as img2nbt, fileToNbt, createNbtStructure, constructDecoded as constructNbt } from "./nbt.ts";
+export { default as img2rgbscreen, fileToRgbScreenNbt, createRgbScreenNbtStructure, constructDecoded as constructRgbScreen } from "./nbt_rgbscreen.ts";
 export { default as img2mcaddon, fileToMcaddon } from "./mcaddon.ts";
 export { default as vox2mcstructure, fileToVoxMcstructure, parseVox, getVoxInfo, constructDecoded as constructVox } from "./vox.ts";
 
@@ -71,6 +72,7 @@ export {
 export {
   BLOCK_VERSION,
   NBT_DATA_VERSION,
+  RGBSCREEN_DATA_VERSION,
   BLOCK_FORMAT_VERSION,
   DEFAULT_BLOCK,
   MASK_BLOCK,
@@ -95,6 +97,7 @@ export type { ConvertOptions } from "./mcstructure.ts";
 export type { McfunctionOptions } from "./mcfunction.ts";
 export type { SchematicOptions } from "./schematic.ts";
 export type { NbtOptions } from "./nbt.ts";
+export type { RgbScreenOptions } from "./nbt_rgbscreen.ts";
 export type { McaddonOptions } from "./mcaddon.ts";
 export type { VoxOptions } from "./vox.ts";
 
@@ -145,6 +148,13 @@ export function downloadSchematic(data: Uint8Array, filename = "structure.schema
  * Helper to download NBT data
  */
 export function downloadNbt(data: Uint8Array, filename = "structure.nbt"): void {
+  downloadBlob(data, filename);
+}
+
+/**
+ * Helper to download RGB Screen NBT data
+ */
+export function downloadRgbScreenNbt(data: Uint8Array, filename = "rgbscreen.nbt"): void {
   downloadBlob(data, filename);
 }
 

--- a/src/client/nbt_rgbscreen.ts
+++ b/src/client/nbt_rgbscreen.ts
@@ -1,0 +1,306 @@
+/**
+ * Client-side RGB Screen NBT encoder for RGB v2 mod
+ * Creates NBT structures using rgbscreen:rgb_screen blocks
+ * Each block stores a 3x3 grid of pixels in an int array
+ * Uses browser-native Canvas API - no Node.js dependencies
+ */
+
+import type { Axis, RGB } from "../types.ts";
+import { MAX_DEPTH } from "./constants.ts";
+import { colorDistance } from "./lib.ts";
+import decode, {
+  colorToRGBA,
+  type DecodeOptions,
+  type DecodedFrames,
+  type ImageFrame,
+  type ImageInput,
+  decodeFile,
+} from "./decode.ts";
+
+export { decode, decodeFile };
+
+/**
+ * RGB Screen data version (Minecraft 1.21+)
+ */
+export const RGBSCREEN_DATA_VERSION = 4556;
+
+/**
+ * Pixels per block dimension (3x3 = 9 pixels per block)
+ */
+export const PIXELS_PER_BLOCK = 3;
+
+/**
+ * RGB Screen color palette
+ * Index maps directly to color value in screen array
+ */
+export const RGB_SCREEN_COLORS: RGB[] = [
+  [255, 255, 255], // 0: White
+  [255, 0, 0],     // 1: Red
+  [0, 255, 0],     // 2: Green
+  [0, 0, 255],     // 3: Blue
+  [255, 255, 0],   // 4: Yellow
+  [0, 255, 255],   // 5: Cyan
+  [255, 0, 255],   // 6: Magenta
+  [0, 0, 0],       // 7: Black
+];
+
+/**
+ * RGB Screen block with NBT data
+ */
+export interface IRgbScreenBlock {
+  nbt: {
+    components: Record<string, unknown>;
+    screen: Int32Array;
+    id: string;
+  };
+  pos: [number, number, number];
+  state: number;
+}
+
+/**
+ * RGB Screen NBT structure format
+ */
+export interface IRgbScreenNbtTag {
+  size: [number, number, number];
+  blocks: IRgbScreenBlock[];
+  palette: Array<{ Name: string }>;
+  entities: Record<string, unknown>[];
+  DataVersion: number;
+}
+
+/**
+ * Find the nearest RGB screen color index for a given RGB color
+ * @param color RGB color to match
+ * @returns Color index (0-7)
+ */
+export function getNearestColorIndex(color: RGB): number {
+  let minDistance = Number.POSITIVE_INFINITY;
+  let nearestIndex = 0;
+
+  for (let i = 0; i < RGB_SCREEN_COLORS.length; i++) {
+    const distance = colorDistance(color, RGB_SCREEN_COLORS[i]);
+    if (distance < minDistance) {
+      minDistance = distance;
+      nearestIndex = i;
+    }
+  }
+
+  return nearestIndex;
+}
+
+/**
+ * Get pixel color at a given position from ImageFrame
+ * @param frame Image frame
+ * @param x X coordinate (1-based, as per imagescript convention)
+ * @param y Y coordinate (1-based)
+ * @returns Packed RGBA color number
+ */
+function getPixelAt(frame: ImageFrame, x: number, y: number): number {
+  const idx = ((y - 1) * frame.width + (x - 1)) * 4;
+  const r = frame.data[idx];
+  const g = frame.data[idx + 1];
+  const b = frame.data[idx + 2];
+  const a = frame.data[idx + 3];
+  return ((r << 24) | (g << 16) | (b << 8) | a) >>> 0;
+}
+
+/**
+ * Extract a 3x3 pixel block from an image and convert to screen array
+ * @param frame Image frame to extract from
+ * @param blockX Block X coordinate (in block units)
+ * @param blockY Block Y coordinate (in block units)
+ * @returns Int32Array with 9 color indices
+ */
+function extractScreenData(
+  frame: ImageFrame,
+  blockX: number,
+  blockY: number,
+): Int32Array {
+  const screen = new Int32Array(9);
+  const startX = blockX * PIXELS_PER_BLOCK;
+  const startY = blockY * PIXELS_PER_BLOCK;
+
+  for (let py = 0; py < PIXELS_PER_BLOCK; py++) {
+    for (let px = 0; px < PIXELS_PER_BLOCK; px++) {
+      const imgX = startX + px + 1; // 1-based indexing
+      const imgY = startY + py + 1;
+      const screenIdx = py * PIXELS_PER_BLOCK + px;
+
+      // Check if pixel is within image bounds
+      if (imgX <= frame.width && imgY <= frame.height) {
+        const c = getPixelAt(frame, imgX, imgY);
+        const [r, g, b, a] = colorToRGBA(c);
+
+        // Use black for transparent pixels
+        if (a < 128) {
+          screen[screenIdx] = 7; // Black
+        } else {
+          screen[screenIdx] = getNearestColorIndex([r, g, b]);
+        }
+      } else {
+        // Out of bounds - use black
+        screen[screenIdx] = 7;
+      }
+    }
+  }
+
+  return screen;
+}
+
+/**
+ * Create an RGB Screen NBT structure from image frames
+ * @param frames Image frames to convert
+ * @param axis Axis orientation
+ * @returns RGB Screen NBT tag
+ */
+export function constructDecoded(
+  frames: DecodedFrames,
+  axis: Axis = "x",
+): IRgbScreenNbtTag {
+  const img = frames[0];
+  const depth = Math.min(frames.length, MAX_DEPTH);
+
+  // Calculate block dimensions (ceil to handle non-divisible sizes)
+  const blocksWide = Math.ceil(img.width / PIXELS_PER_BLOCK);
+  const blocksTall = Math.ceil(img.height / PIXELS_PER_BLOCK);
+
+  const blocks: IRgbScreenBlock[] = [];
+
+  for (let z = 0; z < depth; z++) {
+    const frame = frames[z];
+
+    for (let blockY = 0; blockY < blocksTall; blockY++) {
+      for (let blockX = 0; blockX < blocksWide; blockX++) {
+        const screen = extractScreenData(frame, blockX, blockY);
+
+        // Calculate block position based on axis
+        // For RGB screens, we want a flat wall display
+        // Y in Minecraft is vertical (height)
+        // The image top-left should be at the top-left of the wall
+        const structY = blocksTall - 1 - blockY; // Flip Y so image top is at top
+        const structZ = blockX;
+        const structX = z;
+
+        let pos: [number, number, number];
+        switch (axis) {
+          case "x":
+            pos = [structX, structY, structZ];
+            break;
+          case "y":
+            pos = [structZ, structX, structY];
+            break;
+          case "z":
+            pos = [structZ, structY, structX];
+            break;
+          default:
+            pos = [structX, structY, structZ];
+        }
+
+        blocks.push({
+          nbt: {
+            components: {},
+            screen,
+            id: "rgbscreen:rgb_screen",
+          },
+          pos,
+          state: 0,
+        });
+      }
+    }
+  }
+
+  // Calculate structure size based on axis
+  let size: [number, number, number];
+  switch (axis) {
+    case "x":
+      size = [depth, blocksTall, blocksWide];
+      break;
+    case "y":
+      size = [blocksWide, depth, blocksTall];
+      break;
+    case "z":
+      size = [blocksWide, blocksTall, depth];
+      break;
+    default:
+      size = [depth, blocksTall, blocksWide];
+  }
+
+  return {
+    size,
+    blocks,
+    palette: [{ Name: "rgbscreen:rgb_screen" }],
+    entities: [],
+    DataVersion: RGBSCREEN_DATA_VERSION,
+  };
+}
+
+/**
+ * Create an RGB Screen NBT structure from image frames
+ * @param frames Image frames
+ * @param axis Axis orientation
+ * @returns NBT structure data as Uint8Array
+ */
+export async function createRgbScreenNbtStructure(
+  frames: DecodedFrames,
+  axis: Axis = "x",
+): Promise<Uint8Array> {
+  const decoded = constructDecoded(frames, axis);
+
+  // Dynamic import of nbtify for browser compatibility
+  const nbt = await import("nbtify");
+
+  // nbtify handles native typed arrays correctly:
+  // Int32Array -> TAG_Int_Array in NBT
+  // The data is already in the correct format from constructDecoded()
+
+  return await nbt.write(decoded as unknown as nbt.NBTData, {
+    endian: "big",
+    compression: null,
+    bedrockLevel: false,
+  });
+}
+
+/**
+ * Options for converting an image to RGB Screen NBT
+ */
+export interface RgbScreenOptions {
+  /** Axis orientation */
+  axis?: Axis;
+  /** Decode options */
+  decodeOptions?: DecodeOptions;
+}
+
+/**
+ * Decode an image and convert it to an RGB Screen NBT structure
+ * Client-side version - accepts raw image data
+ * @param input Image data (ArrayBuffer, Uint8Array, base64, or File)
+ * @param options Conversion options
+ * @returns NBT structure data as Uint8Array
+ */
+export default async function img2rgbscreen(
+  input: ImageInput | File,
+  options: RgbScreenOptions = {},
+): Promise<Uint8Array> {
+  const { axis = "x", decodeOptions } = options;
+
+  // Decode image
+  const img =
+    input instanceof File
+      ? await decodeFile(input, decodeOptions)
+      : await decode(input, decodeOptions);
+
+  return await createRgbScreenNbtStructure(img, axis);
+}
+
+/**
+ * Convert a File to RGB Screen NBT (convenience wrapper)
+ * @param file File object from input or drag/drop
+ * @param options Conversion options
+ * @returns NBT structure data as Uint8Array
+ */
+export async function fileToRgbScreenNbt(
+  file: File,
+  options: RgbScreenOptions = {},
+): Promise<Uint8Array> {
+  return img2rgbscreen(file, options);
+}

--- a/src/nbt/rgbscreen.ts
+++ b/src/nbt/rgbscreen.ts
@@ -1,0 +1,248 @@
+/**
+ * RGB Screen NBT encoder for RGB v2 mod
+ * Creates NBT structures using rgbscreen:rgb_screen blocks
+ * Each block stores a 3x3 grid of pixels in an int array
+ */
+
+import type { Axis, RGB } from "../types.ts";
+import * as nbt from "nbtify";
+import * as imagescript from "imagescript";
+import { MAX_DEPTH } from "../_constants.ts";
+import { colorDistance } from "../_lib.ts";
+import decode from "../_decode.ts";
+
+/**
+ * RGB Screen data version (Minecraft 1.21+)
+ */
+export const RGBSCREEN_DATA_VERSION = 4556;
+
+/**
+ * Pixels per block dimension (3x3 = 9 pixels per block)
+ */
+export const PIXELS_PER_BLOCK = 3;
+
+/**
+ * RGB Screen color palette
+ * Index maps directly to color value in screen array
+ */
+export const RGB_SCREEN_COLORS: RGB[] = [
+  [255, 255, 255], // 0: White
+  [255, 0, 0],     // 1: Red
+  [0, 255, 0],     // 2: Green
+  [0, 0, 255],     // 3: Blue
+  [255, 255, 0],   // 4: Yellow
+  [0, 255, 255],   // 5: Cyan
+  [255, 0, 255],   // 6: Magenta
+  [0, 0, 0],       // 7: Black
+];
+
+/**
+ * RGB Screen block with NBT data
+ */
+export interface IRgbScreenBlock {
+  nbt: {
+    components: Record<string, unknown>;
+    screen: Int32Array;
+    id: string;
+  };
+  pos: [number, number, number];
+  state: number;
+}
+
+/**
+ * RGB Screen NBT structure format
+ */
+export interface IRgbScreenNbtTag {
+  size: [number, number, number];
+  blocks: IRgbScreenBlock[];
+  palette: Array<{ Name: string }>;
+  entities: Record<string, unknown>[];
+  DataVersion: number;
+}
+
+/**
+ * Find the nearest RGB screen color index for a given RGB color
+ * @param color RGB color to match
+ * @returns Color index (0-7)
+ */
+export function getNearestColorIndex(color: RGB): number {
+  let minDistance = Number.POSITIVE_INFINITY;
+  let nearestIndex = 0;
+
+  for (let i = 0; i < RGB_SCREEN_COLORS.length; i++) {
+    const distance = colorDistance(color, RGB_SCREEN_COLORS[i]);
+    if (distance < minDistance) {
+      minDistance = distance;
+      nearestIndex = i;
+    }
+  }
+
+  return nearestIndex;
+}
+
+/**
+ * Extract a 3x3 pixel block from an image and convert to screen array
+ * @param img Image to extract from
+ * @param blockX Block X coordinate (in block units)
+ * @param blockY Block Y coordinate (in block units)
+ * @returns Int32Array with 9 color indices
+ */
+function extractScreenData(
+  img: imagescript.Image | imagescript.Frame,
+  blockX: number,
+  blockY: number,
+): Int32Array {
+  const screen = new Int32Array(9);
+  const startX = blockX * PIXELS_PER_BLOCK;
+  const startY = blockY * PIXELS_PER_BLOCK;
+
+  for (let py = 0; py < PIXELS_PER_BLOCK; py++) {
+    for (let px = 0; px < PIXELS_PER_BLOCK; px++) {
+      const imgX = startX + px + 1; // imagescript uses 1-based indexing
+      const imgY = startY + py + 1;
+      const screenIdx = py * PIXELS_PER_BLOCK + px;
+
+      // Check if pixel is within image bounds
+      if (imgX <= img.width && imgY <= img.height) {
+        const c = img.getPixelAt(imgX, imgY);
+        const [r, g, b, a] = imagescript.Image.colorToRGBA(c);
+
+        // Use black for transparent pixels
+        if (a < 128) {
+          screen[screenIdx] = 7; // Black
+        } else {
+          screen[screenIdx] = getNearestColorIndex([r, g, b]);
+        }
+      } else {
+        // Out of bounds - use black
+        screen[screenIdx] = 7;
+      }
+    }
+  }
+
+  return screen;
+}
+
+/**
+ * Create an RGB Screen NBT structure from image frames
+ * @param frames Image frames to convert
+ * @param axis Axis orientation
+ * @returns RGB Screen NBT tag
+ */
+export function constructDecoded(
+  frames: imagescript.GIF | Array<imagescript.Image | imagescript.Frame>,
+  axis: Axis = "x",
+): IRgbScreenNbtTag {
+  const img = frames[0];
+  const depth = Math.min(frames.length, MAX_DEPTH);
+
+  // Calculate block dimensions (ceil to handle non-divisible sizes)
+  const blocksWide = Math.ceil(img.width / PIXELS_PER_BLOCK);
+  const blocksTall = Math.ceil(img.height / PIXELS_PER_BLOCK);
+
+  const blocks: IRgbScreenBlock[] = [];
+
+  for (let z = 0; z < depth; z++) {
+    const frame = frames[z];
+
+    for (let blockY = 0; blockY < blocksTall; blockY++) {
+      for (let blockX = 0; blockX < blocksWide; blockX++) {
+        const screen = extractScreenData(frame, blockX, blockY);
+
+        // Calculate block position based on axis
+        // For RGB screens, we want a flat wall display
+        // Y in Minecraft is vertical (height)
+        // The image top-left should be at the top-left of the wall
+        const structY = blocksTall - 1 - blockY; // Flip Y so image top is at top
+        const structZ = blockX;
+        const structX = z;
+
+        let pos: [number, number, number];
+        switch (axis) {
+          case "x":
+            pos = [structX, structY, structZ];
+            break;
+          case "y":
+            pos = [structZ, structX, structY];
+            break;
+          case "z":
+            pos = [structZ, structY, structX];
+            break;
+          default:
+            pos = [structX, structY, structZ];
+        }
+
+        blocks.push({
+          nbt: {
+            components: {},
+            screen,
+            id: "rgbscreen:rgb_screen",
+          },
+          pos,
+          state: 0,
+        });
+      }
+    }
+  }
+
+  // Calculate structure size based on axis
+  let size: [number, number, number];
+  switch (axis) {
+    case "x":
+      size = [depth, blocksTall, blocksWide];
+      break;
+    case "y":
+      size = [blocksWide, depth, blocksTall];
+      break;
+    case "z":
+      size = [blocksWide, blocksTall, depth];
+      break;
+    default:
+      size = [depth, blocksTall, blocksWide];
+  }
+
+  return {
+    size,
+    blocks,
+    palette: [{ Name: "rgbscreen:rgb_screen" }],
+    entities: [],
+    DataVersion: RGBSCREEN_DATA_VERSION,
+  };
+}
+
+/**
+ * Create an RGB Screen NBT structure from image frames
+ * @param frames Image frames
+ * @param axis Axis orientation
+ * @returns NBT structure data as Uint8Array
+ */
+export async function createRgbScreenNbtStructure(
+  frames: imagescript.GIF | Array<imagescript.Image | imagescript.Frame>,
+  axis: Axis = "x",
+): Promise<Uint8Array> {
+  const decoded = constructDecoded(frames, axis);
+
+  // nbtify handles native typed arrays correctly:
+  // Int32Array -> TAG_Int_Array in NBT
+  // The data is already in the correct format from constructDecoded()
+
+  return await nbt.write(decoded as unknown as nbt.NBTData, {
+    endian: "big",
+    compression: null,
+    bedrockLevel: false,
+  });
+}
+
+/**
+ * Decode an image and convert it to an RGB Screen NBT structure
+ * @param imgSrc Image source path or URL
+ * @param axis Axis orientation
+ * @returns NBT structure data as Uint8Array
+ */
+export default async function img2rgbscreen(
+  imgSrc: string,
+  axis: Axis = "x",
+): Promise<Uint8Array> {
+  const img = await decode(imgSrc);
+  return await createRgbScreenNbtStructure(img, axis);
+}


### PR DESCRIPTION
Add support for the RGB Screen mod (v2) which uses a new block format:
- Block ID: rgbscreen:rgb_screen
- Each block stores 3x3 pixels (9 total) in an int array
- Uses DataVersion 4556 for Minecraft 1.21+

Changes:
- Add db/rgbscreen.json palette file with 8 color indices
- Add src/nbt/rgbscreen.ts server-side encoder
- Add src/client/nbt_rgbscreen.ts client-side encoder
- Update constants with RGBSCREEN_DATA_VERSION
- Export img2rgbscreen from mod.ts and client/mod.ts