### PR TITLE
fix: pin tailwindcss to v3 to fix GitHub Action build failure

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -23,7 +23,7 @@ jobs:
       - run: |
           mkdir -p ./dist
           bun build ./app/index.tsx > ./dist/bundle.js
-      - run: bunx tailwindcss -i ./app/assets/style.css -o ./dist/style.css
+      - run: bunx tailwindcss@3 -i ./app/assets/style.css -o ./dist/style.css
       - name: Update deno.json
         run: |
             jq '.imports.imagescript = "https://deno.land/x/imagescript@1.3.0/mod.ts"' deno.json > deno.json.tmp

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,4 @@
-/** @type {import('npm:tailwindcss').Config} */
+/** @type {import('tailwindcss').Config} */
 export default {
   content: ["./public/**/*.html", "./app/**/*.{js,jsx,ts,tsx,css}"],
   theme: {


### PR DESCRIPTION
TailwindCSS v4 introduced breaking changes including removal of traditional config file support. Pin to v3 to maintain compatibility with the existing tailwind.config.ts configuration.

Also fix the Deno-specific npm: prefix in the config's JSDoc import.