### PR TITLE
Implement RGB v2 client-side features

### DIFF
--- a/src/client/mod.ts
+++ b/src/client/mod.ts
@@ -201,6 +201,7 @@ export {
   img2mcstructureWithWorker,
   img2schematicWithWorker,
   img2nbtWithWorker,
+  img2rgbscreenWithWorker,
   type WorkerDecodedFrames,
   type SerializableFrame,
 } from "./workerManager.ts";


### PR DESCRIPTION
Adds RGB Screen (v2) encoding support to the web worker for offloading heavy computation from the main thread. This enables client-side RGB Screen conversion to work efficiently with large images and GIFs.

- Add constructRgbScreen message type to worker
- Add RGB Screen color matching and block construction in worker
- Add constructRgbScreen method to ConversionWorkerManager
- Add img2rgbscreenWithWorker convenience function
- Export img2rgbscreenWithWorker from client mod.ts