### PR TITLE
fix: ensure proper Uint8Array handling & async encoding across file ops

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,8 @@
 {
   "name": "@jjg/img2mcstructure",
   "version": "1.2.3",
+  "description": "Convert images and 3D models into Minecraft Bedrock structures and related formats.",
+  "license": "GPL-3.0-only",
   "exports": "./mod.ts",
   "fmt": {
     "include": [
@@ -47,12 +49,12 @@
       "./tests/*",
       "./server.ts",
       "./main.ts",
-      "./deno.json"
+      "./deno.lock"
     ],
     "include": [
       "./README.md",
+      "./LICENSE",
       "./src/**/*",
-      "./deps.ts",
       "./mod.ts"
     ]
   },

--- a/src/_decode.ts
+++ b/src/_decode.ts
@@ -71,7 +71,7 @@ export default async function decode(
   }
 
   if (!img) {
-    img = await decodeImageFile(path, await readFile(path));
+    img = await decodeImageFile(path, new Uint8Array(await readFile(path)));
   }
 
   if (!clamp) {

--- a/src/gltf/parser.ts
+++ b/src/gltf/parser.ts
@@ -109,15 +109,21 @@ interface GltfJson {
   }>;
 }
 
+type GltfAccessor = NonNullable<GltfJson["accessors"]>[number];
+type GltfBufferViews = NonNullable<GltfJson["bufferViews"]>;
+
 /**
  * Read accessor data from buffer
  */
 function readAccessor(
-  accessor: GltfJson["accessors"][0],
-  bufferViews: GltfJson["bufferViews"],
+  accessor: GltfAccessor,
+  bufferViews: GltfBufferViews,
   buffers: ArrayBuffer[]
 ): Float32Array | Uint16Array | Uint32Array | Int8Array | Uint8Array | Int16Array {
   const bufferView = bufferViews[accessor.bufferView ?? 0];
+  if (!bufferView) {
+    throw new Error("Missing bufferView for accessor");
+  }
   const buffer = buffers[bufferView.buffer];
   const byteOffset = (bufferView.byteOffset ?? 0) + (accessor.byteOffset ?? 0);
   const componentInfo = COMPONENT_TYPES[accessor.componentType];

--- a/src/mcaddon/mod.ts
+++ b/src/mcaddon/mod.ts
@@ -348,7 +348,10 @@ async function createFlipbook({
     for (let y = 0; y < gridSizeY; y++) {
       const sliceId = `${namespace}_${x}_${y}_1`;
 
-      const flatFrames: imagescript.Image[] = frames.flat();
+      const flatFrames =
+        (frames as Array<imagescript.Image | imagescript.Frame>).flat().map((frame) =>
+          frame.clone()
+        );
 
       const slice = await series2atlas(
         flatFrames.map((frame) =>
@@ -382,7 +385,10 @@ async function createFlipbook({
 
       if (pbr) {
         try {
-          const flatMerFrames: imagescript.Image[] = merTexture.flat();
+          const flatMerFrames =
+            (merTexture as Array<imagescript.Image | imagescript.Frame>).flat().map((frame) =>
+              frame.clone()
+            );
           addon.file(
             `rp/textures/blocks/${sliceId}_mer.png`,
             await (
@@ -401,7 +407,10 @@ async function createFlipbook({
         }
 
         try {
-          const flatNormalFrames: imagescript.Image[] = normalTexture.flat();
+          const flatNormalFrames =
+            (normalTexture as Array<imagescript.Image | imagescript.Frame>).flat().map((frame) =>
+              frame.clone()
+            );
           addon.file(
             `rp/textures/blocks/${sliceId}_normal.png`,
             await (
@@ -692,7 +701,7 @@ export default async function img2mcaddon(
 
   addon.file("rp/textures/terrain_texture.json", terrainTextureJson);
 
-  const icon = decodedFrames[0].clone().resize(150, 150).encode();
+  const icon = await decodedFrames[0].clone().resize(150, 150).encode();
   addon.file("rp/pack_icon.png", icon);
   addon.file("bp/pack_icon.png", icon);
 

--- a/src/obj/mod.ts
+++ b/src/obj/mod.ts
@@ -262,7 +262,7 @@ export async function obj2mc(
   // Read textures
   const textures: imagescript.Image[] = [];
   for (const src of texSources) {
-    const data = await readFile(src);
+    const data = new Uint8Array(await readFile(src));
     const img = await imagescript.decode(data);
     if (img instanceof imagescript.Image) {
       textures.push(img);
@@ -290,17 +290,17 @@ export async function obj2mc(
   }
 
   // Convert data
-  return convertObjData(objs, textures, opts);
+  return await convertObjData(objs, textures, opts);
 }
 
 /**
  * Convert parsed OBJ data to Minecraft model
  */
-export function convertObjData(
+export async function convertObjData(
   objs: ObjData[],
   textures: imagescript.Image[],
   options: Required<ObjConvertOptions>
-): ObjConvertResult {
+): Promise<ObjConvertResult> {
   const nFrames = objs.length;
   const nTextures = textures.length;
   const nFaces = objs[0].faces.length;
@@ -493,7 +493,7 @@ export function convertObjData(
   }
 
   // Encode PNG
-  const pngData = out.encodeSync();
+  const pngData = await out.encode();
 
   return {
     json: model,


### PR DESCRIPTION
- Explicitly wrap readFile results in Uint8Array constructors for type safety
- Convert all Image.encodeSync() calls to async encode() for consistency
- Update convertMeshData and convertObjData to async functions
- Add missing bufferView null check in GLTF parser
- Fix frame cloning in flipbook creation to handle both Image and Frame types
- Update deno.json with description, license, and correct publish includes